### PR TITLE
feat: Add benchmarks.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,10 @@
         "php": ">= 7.4"
     },
     "require-dev": {
+        "azjezz/psl": "^1.9",
         "drupol/php-conventions": "^5",
         "infection/infection": ">= 0.24.0",
+        "phpbench/phpbench": "^1.2",
         "phpstan/phpstan-strict-rules": "^1.0",
         "phpunit/php-code-coverage": "^9.2",
         "phpunit/phpunit": "^9.5"
@@ -43,7 +45,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "tests\\loophp\\iterators\\": "./tests/unit/"
+            "tests\\loophp\\iterators\\": "./tests/unit/",
+            "benchmarks\\loophp\\iterators\\": "./tests/benchmarks/"
         }
     },
     "config": {

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,10 @@
+{
+    "$schema":"./vendor/phpbench/phpbench/phpbench.schema.json",
+    "runner.bootstrap": "vendor/autoload.php",
+    "runner.path": "tests/benchmarks",
+    "report.generators": {
+        "test": {
+            "extends": "aggregate"
+        }
+    }
+}

--- a/tests/benchmarks/GeneratorCacheBench.php
+++ b/tests/benchmarks/GeneratorCacheBench.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace benchmarks\loophp\iterators;
+
+use Exception;
+use Generator;
+use loophp\iterators\CachingIteratorAggregate;
+use PhpBench\Benchmark\Metadata\Annotations\Groups;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
+use Traversable;
+use Psl\Iter\Iterator as IterIterator;
+
+/**
+ * @Groups({"GeneratorCache"})
+ * @Iterations(10)
+ * @Warmup(1)
+ * @Revs(100)
+ */
+class GeneratorCacheBench
+{
+    /**
+     * @ParamProviders("provideGenerators")
+     */
+    public function benchIterators(array $params): void
+    {
+        $generator = static function(): Generator
+        {
+            yield true => true;
+            yield false => false;
+            yield ['a'] => ['a'];
+            yield from range(0, 250);
+        };
+
+        $iterator = new $params['class']($generator());
+
+        $this->test($iterator);
+    }
+
+    public function provideGenerators(): Generator
+    {
+        yield 'loophp/iterators' => ['class' => CachingIteratorAggregate::class];
+        yield 'azjezz/psl' => ['class' => IterIterator::class];
+    }
+
+    private function test(Traversable $input): void
+    {
+        $a = $b = [];
+
+        foreach ($input as $key => $value) {
+            $a[] = [$key, $value];
+        }
+
+        foreach ($input as $key => $value) {
+            $b[] = [$key, $value];
+        }
+
+        if ($a !== $b) {
+            throw new Exception('$a !== $b');
+        }
+    }
+}


### PR DESCRIPTION
Current results:

```
PHPBench (1.2.2) running benchmarks...
with configuration file: /home/pol/dev/git/iterators/phpbench.json
with PHP version 8.0.13, xdebug ❌, opcache ❌

\benchmarks\loophp\iterators\GeneratorCacheBench

    benchIterators # loophp/iterators.......I9 - Mo137.341μs (±10.28%)
    benchIterators # azjezz/psl.............I9 - Mo6.831ms (±3.89%)

Subjects: 1, Assertions: 0, Failures: 0, Errors: 0
+---------------------+----------------+------------------+------+-----+----------+-----------+---------+
| benchmark           | subject        | set              | revs | its | mem_peak | mode      | rstdev  |
+---------------------+----------------+------------------+------+-----+----------+-----------+---------+
| GeneratorCacheBench | benchIterators | loophp/iterators | 100  | 10  | 6.943mb  | 137.341μs | ±10.28% |
| GeneratorCacheBench | benchIterators | azjezz/psl       | 100  | 10  | 6.932mb  | 6.831ms   | ±3.89%  |
+---------------------+----------------+------------------+------+-----+----------+-----------+---------+
```

