### PR TITLE
Fix typo in class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The missing PHP iterators.
 * `PackIterableAggregate`
 * `UnpackIterableAggregate`
 * `PausableIteratorAggregate`
-* `RandomIteratorAggregate`
+* `RandomIterableAggregate`
 
 ## Installation
 


### PR DESCRIPTION
This PR:

* [x] Fixes a typo in a class name in the readme
* [ ] Provide ...
* [ ] It breaks backward compatibility
* [ ] Has unit tests (phpspec)
* [ ] Has static analysis tests (psalm, phpstan)
* [ ] Has documentation
* [ ] Is an experimental thing

Follows #.
Related to #.
Fixes #.
