### PR TITLE
Small improvements for the new `SortIterator`

### DIFF
--- a/src/SortIterator.php
+++ b/src/SortIterator.php
@@ -19,7 +19,7 @@ final class SortIterator extends SplHeap
      * @param iterable<TKey, T> $iterable
      * @param Closure(T, T): int $callback
      */
-    public function __construct(private iterable $iterable, private Closure $callback)
+    public function __construct(iterable $iterable, private Closure $callback)
     {
         foreach ($iterable as $value) {
             $this->insert($value);
@@ -30,7 +30,7 @@ final class SortIterator extends SplHeap
      * @param T $left
      * @param T $right
      */
-    public function compare($left, $right): int
+    protected function compare($left, $right): int
     {
         return ($this->callback)($left, $right);
     }


### PR DESCRIPTION
- Removes `$iterable` as class field (it's only used in the constructor)
- Changes the visibility of the `compare()` method to `protected` (so that it is the same as in the parent class)

Follows 0c810abcdb
