### PR TITLE
fix: allow inner loop traversals of SimpleCachingIteratorAggregate

### DIFF
--- a/src/SimpleCachingIteratorAggregate.php
+++ b/src/SimpleCachingIteratorAggregate.php
@@ -50,12 +50,18 @@ final class SimpleCachingIteratorAggregate implements IteratorAggregate
 
             yield $key = $this->iterator->key() => $this->iterator->current();
 
+            $cache = $this->iterator->getCache();
+
+            if (array_key_last($cache) === $key) {
+                continue;
+            }
+
             // If the cache pointer has shifted since last iteration
             // (inner loop over the same iterator), it's necessary to yield
             // extra-cached items as well
             $yieldStarted = false;
 
-            foreach ($this->iterator->getCache() as $cacheKey => $cacheItem) {
+            foreach ($cache as $cacheKey => $cacheItem) {
                 if ($yieldStarted) {
                     yield $cacheKey => $cacheItem;
                 }

--- a/src/SimpleCachingIteratorAggregate.php
+++ b/src/SimpleCachingIteratorAggregate.php
@@ -52,13 +52,13 @@ final class SimpleCachingIteratorAggregate implements IteratorAggregate
 
             $cache = $this->iterator->getCache();
 
-            if ($key === array_key_last($cache)) {
+            if (array_key_last($cache) === $key) {
                 continue;
             }
 
-            // If the cache pointer has shifted since last iteration (inner loop over the same iterator),
-            // it's necessary to yield extra-cached items as well
-
+            // If the cache pointer has shifted since last iteration
+            // (inner loop over the same iterator), it's necessary to yield
+            // extra-cached items as well
             $yieldStarted = false;
 
             foreach ($cache as $cacheKey => $cacheItem) {
@@ -66,9 +66,7 @@ final class SimpleCachingIteratorAggregate implements IteratorAggregate
                     yield $cacheKey => $cacheItem;
                 }
 
-                if ($key === $cacheKey) {
-                    $yieldStarted = true;
-                }
+                $yieldStarted = $yieldStarted || $key === $cacheKey;
             }
         }
     }

--- a/src/SimpleCachingIteratorAggregate.php
+++ b/src/SimpleCachingIteratorAggregate.php
@@ -50,18 +50,12 @@ final class SimpleCachingIteratorAggregate implements IteratorAggregate
 
             yield $key = $this->iterator->key() => $this->iterator->current();
 
-            $cache = $this->iterator->getCache();
-
-            if (array_key_last($cache) === $key) {
-                continue;
-            }
-
             // If the cache pointer has shifted since last iteration
             // (inner loop over the same iterator), it's necessary to yield
             // extra-cached items as well
             $yieldStarted = false;
 
-            foreach ($cache as $cacheKey => $cacheItem) {
+            foreach ($this->iterator->getCache() as $cacheKey => $cacheItem) {
                 if ($yieldStarted) {
                     yield $cacheKey => $cacheItem;
                 }

--- a/src/SimpleCachingIteratorAggregate.php
+++ b/src/SimpleCachingIteratorAggregate.php
@@ -48,7 +48,28 @@ final class SimpleCachingIteratorAggregate implements IteratorAggregate
         while ($this->iterator->hasNext()) {
             $this->iterator->next();
 
-            yield $this->iterator->key() => $this->iterator->current();
+            yield $key = $this->iterator->key() => $this->iterator->current();
+
+            $cache = $this->iterator->getCache();
+
+            if ($key === array_key_last($cache)) {
+                continue;
+            }
+
+            // If the cache pointer has shifted since last iteration (inner loop over the same iterator),
+            // it's necessary to yield extra-cached items as well
+
+            $yieldStarted = false;
+
+            foreach ($cache as $cacheKey => $cacheItem) {
+                if ($yieldStarted) {
+                    yield $cacheKey => $cacheItem;
+                }
+
+                if ($key === $cacheKey) {
+                    $yieldStarted = true;
+                }
+            }
         }
     }
 

--- a/tests/unit/SimpleCachingIteratorAggregateTest.php
+++ b/tests/unit/SimpleCachingIteratorAggregateTest.php
@@ -44,6 +44,39 @@ final class SimpleCachingIteratorAggregateTest extends TestCase
         self::assertSame([1, 2, 3, 4, 5, 6], $outerItems);
     }
 
+    public function testSecondTraversalEliminatesDuplicatedKeys(): void
+    {
+        $input = static function (): Generator {
+            yield 'a' => 1;
+            yield 'a' => 2;
+            yield 'a' => 3;
+        };
+
+        $iter = new SimpleCachingIteratorAggregate($input());
+
+        $firstIterationItems = [];
+
+        foreach ($iter as $ko => $vo) {
+            $firstIterationItems[] = [$ko, $vo];
+        }
+
+        $secondIterationItems = [];
+
+        foreach ($iter as $ko => $vo) {
+            $secondIterationItems[] = [$ko, $vo];
+        }
+
+        self::assertSame([
+            ['a', 1],
+            ['a', 2],
+            ['a', 3],
+        ], $firstIterationItems);
+
+        self::assertSame([
+            ['a', 3],
+        ], $secondIterationItems);
+    }
+
     public function testHasNext(): void
     {
         $range = range('a', 'c');

--- a/tests/unit/SimpleCachingIteratorAggregateTest.php
+++ b/tests/unit/SimpleCachingIteratorAggregateTest.php
@@ -21,6 +21,29 @@ use PHPUnit\Framework\TestCase;
  */
 final class SimpleCachingIteratorAggregateTest extends TestCase
 {
+    public function testConsecutiveCachingFromInnerTraversals(): void
+    {
+        $iterator = new SimpleCachingIteratorAggregate(new ArrayIterator([1, 2, 3, 4, 5, 6]));
+        $outerItems = $innerItems = [];
+
+        foreach ($iterator as $outerItem) {
+            $outerItems[] = $outerItem;
+
+            if (2 === $outerItem) {
+                foreach ($iterator as $innerItem) {
+                    $innerItems[] = $innerItem;
+
+                    if (4 === $innerItem) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        self::assertSame([1, 2, 3, 4], $innerItems);
+        self::assertSame([1, 2, 3, 4, 5, 6], $outerItems);
+    }
+
     public function testHasNext(): void
     {
         $range = range('a', 'c');
@@ -104,32 +127,5 @@ final class SimpleCachingIteratorAggregateTest extends TestCase
         ];
 
         self::assertSame($expected, $a);
-    }
-
-    public function testConsecutiveCachingFromInnerTraversals(): void
-    {
-        $iterator = new SimpleCachingIteratorAggregate(new ArrayIterator([1, 2, 3, 4, 5, 6]));
-
-        $outerItems = [];
-
-        foreach ($iterator as $outerItem) {
-            if ($outerItem === 2) {
-                $innerItems = [];
-
-                foreach ($iterator as $innerItem) {
-                    $innerItems[] = $innerItem;
-
-                    if ($innerItem === 4) {
-                        break;
-                    }
-                }
-
-                self::assertSame([1, 2, 3, 4], $innerItems);
-            }
-
-            $outerItems[] = $outerItem;
-        }
-
-        self::assertSame([1, 2, 3, 4, 5, 6], $outerItems);
     }
 }

--- a/tests/unit/SimpleCachingIteratorAggregateTest.php
+++ b/tests/unit/SimpleCachingIteratorAggregateTest.php
@@ -105,4 +105,31 @@ final class SimpleCachingIteratorAggregateTest extends TestCase
 
         self::assertSame($expected, $a);
     }
+
+    public function testConsecutiveCachingFromInnerTraversals(): void
+    {
+        $iterator = new SimpleCachingIteratorAggregate(new ArrayIterator([1, 2, 3, 4, 5, 6]));
+
+        $outerItems = [];
+
+        foreach ($iterator as $outerItem) {
+            if ($outerItem === 2) {
+                $innerItems = [];
+
+                foreach ($iterator as $innerItem) {
+                    $innerItems[] = $innerItem;
+
+                    if ($innerItem === 4) {
+                        break;
+                    }
+                }
+
+                self::assertSame([1, 2, 3, 4], $innerItems);
+            }
+
+            $outerItems[] = $outerItem;
+        }
+
+        self::assertSame([1, 2, 3, 4, 5, 6], $outerItems);
+    }
 }


### PR DESCRIPTION
This PR adds consecutive caching to `SimpleCachingIteratorAggregate` allowing to traverse the same iterator within the loop without affecting outer iteration.

See https://github.com/loophp/iterators/issues/49
