### PR TITLE
refactor: rewrite `RandomIterableAggregate` to avoid recursion

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,16 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^While loop condition is always true\\.$#"
+			count: 1
+			path: src/RandomIntegerAggregate.php
+
+		-
+			message: "#^Parameter \\#1 \\$iterable of class loophp\\\\iterators\\\\UnpackIterableAggregate constructor expects iterable\\<\\(int\\|string\\), array\\{TKey, T\\}\\>, loophp\\\\iterators\\\\UnpackIterableAggregate\\<array\\{TKey, T\\}\\|int\\|null, array\\{TKey, T\\}\\|int\\|null\\> given\\.$#"
+			count: 1
+			path: src/RandomIterableAggregate.php
+
+		-
+			message: "#^Parameter \\#1 \\$iterable of class loophp\\\\iterators\\\\UnpackIterableAggregate constructor expects iterable\\<\\(int\\|string\\), array\\{array\\{TKey, T\\}\\|int\\|null, array\\{TKey, T\\}\\|int\\|null\\}\\>, loophp\\\\iterators\\\\SortIterableAggregate\\<array\\<int, int\\|null\\>, array\\<int, array\\{TKey, T\\}\\|int\\|null\\>\\> given\\.$#"
+			count: 1
+			path: src/RandomIterableAggregate.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,2 @@
+includes:
+	- phpstan-baseline.neon

--- a/src/RandomIntegerAggregate.php
+++ b/src/RandomIntegerAggregate.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\iterators;
+
+use Generator;
+use IteratorAggregate;
+
+use const PHP_INT_MAX;
+
+/**
+ * @implements IteratorAggregate<int, int>
+ */
+final class RandomIntegerAggregate implements IteratorAggregate
+{
+    public function __construct(
+        private readonly ?int $seed = null,
+        private readonly int $min = 0,
+        private readonly int $max = PHP_INT_MAX,
+    ) {}
+
+    /**
+     * @return Generator<int, int>
+     */
+    public function getIterator(): Generator
+    {
+        if (null !== $this->seed) {
+            mt_srand($this->seed);
+        }
+
+        while (true) {
+            yield mt_rand($this->min, $this->max);
+        }
+    }
+}

--- a/src/SortIterableAggregate.php
+++ b/src/SortIterableAggregate.php
@@ -21,7 +21,10 @@ final class SortIterableAggregate implements IteratorAggregate
      * @param iterable<TKey, T> $iterable
      * @param Closure(T, T, TKey, TKey): int $callback
      */
-    public function __construct(private readonly iterable $iterable, private readonly Closure $callback) {}
+    public function __construct(
+        private readonly iterable $iterable,
+        private readonly Closure $callback
+    ) {}
 
     /**
      * @return Generator<TKey, T>

--- a/tests/unit/RandomIterableAggregateTest.php
+++ b/tests/unit/RandomIterableAggregateTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 
 use function count;
 
+use const PHP_VERSION_ID;
+
 /**
  * @internal
  *
@@ -22,13 +24,17 @@ use function count;
  */
 final class RandomIterableAggregateTest extends TestCase
 {
-    public function testSeed(): void
+    public function testSeedWithPHP81AndSmaller(): void
     {
+        if (PHP_VERSION_ID >= 80200) {
+            self::markTestSkipped('This test is only for PHP 8.1 and smaller.');
+        }
+
         $input = static function (): Generator {
             yield from array_combine(range('a', 'z'), range('a', 'z'));
         };
 
-        $iterator = (new RandomIterableAggregate($input()));
+        $iterator = (new RandomIterableAggregate($input(), 0));
 
         $a = [];
 
@@ -36,14 +42,96 @@ final class RandomIterableAggregateTest extends TestCase
             $a[$key] = $value;
         }
 
-        $expected = array_combine(range('a', 'z'), range('a', 'z'));
+        $expected = [
+            'q' => 'q',
+            'l' => 'l',
+            'd' => 'd',
+            'a' => 'a',
+            'm' => 'm',
+            'o' => 'o',
+            'p' => 'p',
+            'c' => 'c',
+            'y' => 'y',
+            'z' => 'z',
+            'f' => 'f',
+            'b' => 'b',
+            's' => 's',
+            'x' => 'x',
+            'k' => 'k',
+            'v' => 'v',
+            'r' => 'r',
+            't' => 't',
+            'j' => 'j',
+            'h' => 'h',
+            'e' => 'e',
+            'n' => 'n',
+            'g' => 'g',
+            'w' => 'w',
+            'i' => 'i',
+            'u' => 'u',
+        ];
 
         self::assertSame(iterator_count($input()), count($expected));
         self::assertSame($expected, $a);
     }
 
-    public function testSimple(): void
+    public function testSeedWithPHP82AndGreater(): void
     {
+        if (PHP_VERSION_ID < 80200) {
+            self::markTestSkipped('This test is only for PHP 8.1 and smaller.');
+        }
+
+        $input = static function (): Generator {
+            yield from array_combine(range('a', 'z'), range('a', 'z'));
+        };
+
+        $iterator = (new RandomIterableAggregate($input(), 0));
+
+        $a = [];
+
+        foreach ($iterator as $key => $value) {
+            $a[$key] = $value;
+        }
+
+        $expected = [
+            'w' => 'w',
+            'h' => 'h',
+            'z' => 'z',
+            'a' => 'a',
+            'e' => 'e',
+            's' => 's',
+            'p' => 'p',
+            'x' => 'x',
+            'y' => 'y',
+            'i' => 'i',
+            'g' => 'g',
+            'v' => 'v',
+            'k' => 'k',
+            'n' => 'n',
+            'o' => 'o',
+            'b' => 'b',
+            'd' => 'd',
+            'c' => 'c',
+            'q' => 'q',
+            't' => 't',
+            'f' => 'f',
+            'm' => 'm',
+            'r' => 'r',
+            'u' => 'u',
+            'j' => 'j',
+            'l' => 'l',
+        ];
+
+        self::assertSame(iterator_count($input()), count($expected));
+        self::assertSame($expected, $a);
+    }
+
+    public function testSimpleWithPHP81AndSmaller(): void
+    {
+        if (PHP_VERSION_ID >= 80200) {
+            self::markTestSkipped('This test is only for PHP 8.1 and smaller.');
+        }
+
         $input = static function (): Generator {
             yield from array_combine(range('a', 'f'), range('a', 'f'));
         };
@@ -59,12 +147,45 @@ final class RandomIterableAggregateTest extends TestCase
         }
 
         $expected = [
-            ['a', 'a'],
             ['b', 'b'],
-            ['d', 'd'],
-            ['f', 'f'],
             ['c', 'c'],
+            ['f', 'f'],
             ['e', 'e'],
+            ['d', 'd'],
+            ['a', 'a'],
+        ];
+
+        self::assertSame(iterator_count($input()), count($expected));
+        self::assertSame($expected, $a);
+    }
+
+    public function testSimpleWithPHP82AndGreater(): void
+    {
+        if (PHP_VERSION_ID < 80200) {
+            self::markTestSkipped('This test is only for PHP 8.2 and greater.');
+        }
+
+        $input = static function (): Generator {
+            yield from array_combine(range('a', 'f'), range('a', 'f'));
+        };
+
+        $seed = 2;
+
+        $iterator = (new RandomIterableAggregate($input(), $seed));
+
+        $a = [];
+
+        foreach ($iterator as $key => $value) {
+            $a[] = [$key, $value];
+        }
+
+        $expected = [
+            ['f', 'f'],
+            ['a', 'a'],
+            ['e', 'e'],
+            ['b', 'b'],
+            ['c', 'c'],
+            ['d', 'd'],
         ];
 
         self::assertSame(iterator_count($input()), count($expected));


### PR DESCRIPTION
This PR:

- [x] Remove recursion in `RandomIterableAggregate`, potentially avoiding memory issues.
- [x] I really like this new implementation :D

Related to PR: https://github.com/loophp/collection/issues/332