### PR TITLE
Export ignore phpstan.neon.dist instead of phpstan.neon

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,6 @@
 /phpspec.yml export-ignore
 /psalm.xml export-ignore
 /phpstan-baseline.neon export-ignore
-/phpstan.neon export-ignore
+/phpstan.neon.dist export-ignore
 /phpunit.xml export-ignore
 /README.md export-ignore


### PR DESCRIPTION
This PR:

- [x] Fixes dist installation of the package
- [ ] Provide ...
- [ ] It breaks backward compatibility
- [ ] Has unit tests (phpspec)
- [ ] Has static analysis tests (psalm, phpstan)
- [ ] Has documentation
- [ ] Is an experimental thing

Follows #. Related to #. Fixes #.
