### PR TITLE
Remove renovate.json from dist version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,4 +23,5 @@
 /phpstan-baseline.neon export-ignore
 /phpstan.neon.dist export-ignore
 /phpunit.xml export-ignore
+/renovate.json export-ignore
 /README.md export-ignore


### PR DESCRIPTION
This PR:

- [ ] Fix ...
- [x] Provides a dist version without renovate.json config file
- [ ] It breaks backward compatibility
- [ ] Has unit tests (phpspec)
- [ ] Has static analysis tests (psalm, phpstan)
- [ ] Has documentation
- [ ] Is an experimental thing

Follows #. Related to #. Fixes #.
