### PR TITLE
Add `RecursiveIterableAggregate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The missing PHP iterators.
 - `PackIterableAggregate`
 - `PausableIteratorAggregate`
 - `RandomIterableAggregate`
+- `RecursiveIterableAggregate`
 - `ReductionIterableAggregate`
 - `ResourceIteratorAggregate`
 - `SimpleCachingIteratorAggregate`
@@ -305,6 +306,49 @@ foreach ($iterator as $v) {
 }
 foreach ($iterator as $v) {
     var_dump($v);
+}
+```
+
+### RecursiveIterableAggregate
+
+This iterator allows you to iterate through tree-like structures by simply
+providing an `iterable` and callback to access its children.
+
+```php
+<?php
+
+$treeStructure = [
+    [
+        'value' => '1',
+        'children' => [
+            [
+                'value' => '1.1',
+                'children' => [
+                    [
+                        'value' => '1.1.1',
+                        'children' => [],
+                    ],
+                ],
+            ],
+            [
+                'value' => '1.2',
+                'children' => [],
+            ],
+        ],
+    ],
+    [
+        'value' => '2',
+        'children' => [],
+    ],
+];
+
+$iterator = new RecursiveIterableAggregate(
+    $treeStructure,
+    fn (array $i) => $i['children']
+);
+
+foreach ($iterator as $item) {
+    var_dump($item['value']); // This will print '1', '1.1', '1.1.1', '1.2', '2'
 }
 ```
 

--- a/src/RecursiveIterableAggregate.php
+++ b/src/RecursiveIterableAggregate.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\iterators;
+
+use Closure;
+use Generator;
+use IteratorAggregate;
+
+/**
+ * @template TKey
+ * @template T
+ *
+ * @implements IteratorAggregate<TKey, T>
+ */
+class RecursiveIterableAggregate implements IteratorAggregate
+{
+    /**
+     * @param iterable<TKey, T> $iterable
+     * @param (Closure(T, TKey, iterable<TKey, T>): iterable<TKey, T>) $closure
+     */
+    public function __construct(private iterable $iterable, private Closure $closure) {}
+
+    /**
+     * @return Generator<TKey, T>
+     */
+    public function getIterator(): Generator
+    {
+        yield from $this->flatten($this->iterable);
+    }
+
+    /**
+     * @param iterable<TKey, T> $items
+     *
+     * @return Generator<TKey, T>
+     */
+    private function flatten(iterable $items): Generator
+    {
+        foreach ($items as $key => $value) {
+            yield $key => $value;
+
+            yield from $this->flatten(($this->closure)($value, $key, $this->iterable));
+        }
+    }
+}

--- a/tests/unit/RecursiveIterableAggregateTest.php
+++ b/tests/unit/RecursiveIterableAggregateTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\loophp\iterators;
+
+use Generator;
+use loophp\iterators\RecursiveIterableAggregate;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @coversDefaultClass \loophp\iterators
+ */
+final class RecursiveIterableAggregateTest extends TestCase
+{
+    /**
+     * @return Generator<array{0: array, 1: array}>
+     */
+    public static function provideBasicCases(): iterable
+    {
+        yield [
+            [
+                'i0' => [
+                    'index' => 0,
+                    'children' => [],
+                ],
+                'i1' => [
+                    'index' => 1,
+                    'children' => [],
+                ],
+            ],
+            [
+                'i0' => [
+                    'index' => 0,
+                    'children' => [],
+                ],
+                'i1' => [
+                    'index' => 1,
+                    'children' => [],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'i0' => [
+                    'index' => 0,
+                    'children' => [
+                        'i1' => [
+                            'index' => 1,
+                            'children' => [
+                                'i2' => [
+                                    'index' => 2,
+                                    'children' => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'i0' => [
+                    'index' => 0,
+                    'children' => [
+                        'i1' => [
+                            'index' => 1,
+                            'children' => [
+                                'i2' => [
+                                    'index' => 2,
+                                    'children' => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'i1' => [
+                    'index' => 1,
+                    'children' => [
+                        'i2' => [
+                            'index' => 2,
+                            'children' => [],
+                        ],
+                    ],
+                ],
+                'i2' => [
+                    'index' => 2,
+                    'children' => [],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideBasicCases
+     */
+    public function testBasic(array $input, array $expected): void
+    {
+        self::assertEquals(
+            iterator_to_array(
+                new RecursiveIterableAggregate($input, static fn (array $i) => $i['children'])
+            ),
+            $expected
+        );
+    }
+}


### PR DESCRIPTION
Hello,

First, I'd like to say: great library you have here!

I was hoping to contribute by __adding `RecursiveIterableAggregate` for traversing tree-like structures__, but I didn't check the open pull requests first and, ironically, found a [very similar PR already in progress](https://github.com/loophp/iterators/pull/56). Since the work I've done isn't much, feel free to discard this PR if you find it unnecessary.

I’m not sure if the class name is correct, but I’ve tried to find inspiration in `MapIterableAggregate` and model this class similarly. I’ve also aimed to pass the callback arguments in the same way that `MapIterableAggregate` does (i.e., passing value, key, and the original iterable).